### PR TITLE
Fix missing resource error on service class

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -29,10 +29,17 @@ class jmeter::server($server_ip = '0.0.0.0') {
     }
   }
 
+  if $jmeter::jmeter_plugins_install == true {
+    $jmeter_subscribe = [File['/etc/init.d/jmeter'], Jmeter::Plugins_install[$jmeter::jmeter_plugins_set]]
+  }
+  else {
+    $jmeter_subscribe = [File['/etc/init.d/jmeter']]
+  }
+
   service { 'jmeter':
     ensure    => running,
     enable    => true,
     require   => File['/etc/init.d/jmeter'],
-    subscribe => [File['/etc/init.d/jmeter'], Exec['install-jmeter-plugins']],
+    subscribe => $jmeter_subscribe,
   }
 }


### PR DESCRIPTION
Hi,

I hit an error when trying to use the jmeter::server class. I got an error due to the Exec['install-jmeter-plugins'] resource not existing.

Amended the code to fix this issue.