### PR TITLE
Fix restart function for redhat service script

### DIFF
--- a/templates/jmeter-init.redhat.erb
+++ b/templates/jmeter-init.redhat.erb
@@ -17,13 +17,14 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="Apache JMeter Remote Server"
 NAME=jmeter
 JMETER_PATH=/usr/share/jmeter
+# RMI_HOST_DEF is used inside the $JMETER_PATH/bin/$NAME-server script
 # Change this to your IP
-RMI_HOST_DEF="-Djava.rmi.server.hostname=<%= @server_ip %>"
+export RMI_HOST_DEF="-Djava.rmi.server.hostname=<%= @server_ip %>"
 SERVER_PORT=1099
 SERVER_CMD="$JMETER_PATH/bin/$NAME-server"
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
-JAVA_PID=`ps ax --width=1000 | grep "[A]pacheJMeter.jar -Dserver_port=1099 -s"|awk '{printf $1 ""}'`
+JAVA_PID=$(pgrep -f "[A]pacheJMeter.jar $RMI_HOST_DEF -Dserver_port=1099")
 
 # Source function library.
 . /etc/rc.d/init.d/functions
@@ -36,6 +37,13 @@ JAVA_PID=`ps ax --width=1000 | grep "[A]pacheJMeter.jar -Dserver_port=1099 -s"|a
 
 [ -f $JMETER_PATH/bin/$NAME-server ] || exit 0
 [ -f $JMETER_PATH/bin/$NAME ] || exit 0
+
+# Function that gets the PID of the java process
+#
+update_pid()
+{
+    JAVA_PID=$(pgrep -f "[A]pacheJMeter.jar $RMI_HOST_DEF -Dserver_port=1099")
+}
 
 #
 # Function that starts the daemon/service
@@ -59,6 +67,7 @@ do_stop()
         [ -z "$JAVA_PID" ] && echo "$NAME already stopped" && exit 0
         echo -n "Shutting down $NAME: "
         kill $JAVA_PID
+        sleep 5
         RETVAL=$?
         echo
         [ $RETVAL = 0 ] && rm -f /var/lock/subsys/$NAME
@@ -85,6 +94,7 @@ do_status()
 do_restart()
 {
         do_stop
+        update_pid
         do_start
 }
 


### PR DESCRIPTION
Hi,

I found that when attempting to restart the jmeter service, it was stopping the java instance but was not starting it again as it thinks that jmeter is already running.

Updated the service script to fix this.

Also found that the ip address was not being picked up. Added an export on RMI_HOST_DEF so that the  /usr/share/jmeter/bin/jmeter-server script can now find the IP to use.