### PR TITLE
using best practise for installing packages

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,17 +21,7 @@ class jmeter (
     redhat => "java-1.${java_version}.0-openjdk"
   }
 
-  package { $jdk_pkg:
-    ensure => present,
-  }
-
-  package { 'unzip':
-    ensure => present,
-  }
-
-  package { 'wget':
-    ensure => present,
-  }
+  ensure_resource('package', [$jdk_pkg, 'unzip', 'wget'], {'ensure' => 'present'})
 
   exec { 'download-jmeter':
     command => "wget -P /root http://archive.apache.org/dist/jmeter/binaries/apache-jmeter-${jmeter_version}.tgz",


### PR DESCRIPTION
You shouldn't just use a package resource when installing a package, unless that package is unique for the application being installed in the module.

For things like unzip, people may have installed this in other modules being run on the same host and therefore they get a duplicate resource definition.

I've updated the packages to use the ensure_resource function which gets around this problem and only attempts to install the package if it doesn't already exist. Note this function requires the puppetlabs-stdlibs module