### PR TITLE
Switch to Puppet 4 data types (and drop Puppet 3 support)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'puppetlabs_spec_helper', :groups => [:test]
+gem 'rspec-puppet-facts', :groups => [:test]
 
 if facterversion = ENV['FACTER_GEM_VERSION']
     gem 'facter', facterversion.to_s, :require => false, :groups => [:test]
@@ -38,8 +39,7 @@ group :system_tests do
   gem 'beaker', *location_for(ENV['BEAKER_VERSION'])                             if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0') and ! supports_windows
   gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '< 3')                    if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.3.0') and ! supports_windows
   gem 'beaker-pe',                                                               :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')
-  gem 'beaker-rspec', *location_for(ENV['BEAKER_RSPEC_VERSION'] || '>= 3.4')     if ! supports_windows
-  gem 'beaker-rspec', *location_for(ENV['BEAKER_RSPEC_VERSION'] || '~> 5.1')     if supports_windows
+  gem 'beaker-rspec',                                                            :require => false
   gem 'beaker-puppet_install_helper',                                            :require => false
   gem 'master_manipulator',                                                      :require => false
   gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ group :system_tests do
   gem 'beaker-pe',                                                               :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')
   gem 'beaker-rspec',                                                            :require => false
   gem 'beaker-puppet_install_helper',                                            :require => false
+  gem 'beaker-module_install_helper',                                            :require => false
   gem 'master_manipulator',                                                      :require => false
   gem 'beaker-hostgenerator', *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
   gem 'beaker-abs', *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')        

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ The init script is based on the one available at https://gist.github.com/2830209
 
 Note: If you are using 3.x (the default version), you will need to have at least Java 8 installed.
 
+Requirements
+------------
+
+This module requires Puppet 4.7.1 or higher, as well as the stdlib and
+puppet-archive modules.
+
 Basic usage
 -----------
 
@@ -48,5 +54,4 @@ Install a plugin (if not using the `jmeter::plugins` example above):
     jmeter_plugin { 'foo':
       ensure => present,
     }
-
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,57 +21,51 @@
 #     bind_ip       => 10.3.3.6,
 #   }
 #
-# @param bind_ip [String] IP address to bind to. Defaults to '0.0.0.0' (all interfaces). Replaces `jmeter::server::server_ip`
-# @param checksum_type [String] Checksum type to use for all download commands that use one. You can set to 'none' to disable this check.
-# @param cmdrunner_checksum [String] Checksum for the cmdrunner .jar.
-# @param cmdrunner_version [String] Version of cmdrunner to use. This should generally be left as default.
-# @param download_url [String] Download URL for Jmeter.
-# @param enable_server [Boolean] Whether to enable the server. Replaces the previous method of declaring `class { 'jmeter::server': }`
-# @param java_version [String] Java version to install.
-# @param jdk_pkg [Boolean] Name for the jdk package.
-# @param jmeter_version [String] Sets version of jmeter to install. Note that 3.x requires Java v8.
-# @param jmeter_checksum [String] Checksum for the Jmeter binary.
-# @param manage_java [Boolean] Whether to ensure that java is installed.
-# @param plugin_manager_checksum [String] Checksum for the plugin manager download.
-# @param plugin_manager_install [Boolean] Whether or not to install the plugin manager.
-# @param plugin_manager_url [String] Download URL for both the plugin manager and command runner. Note, this redirects, and part of the path has the package name appended and is built dynamically in jmeter::install.
-# @param plugin_manager_version [String] Sets the version of the plugin manager to install.
+# @param bind_ip IP address to bind to. Defaults to '0.0.0.0' (all interfaces). Replaces `jmeter::server::server_ip`
+# @param checksum_type Checksum type to use for all download commands that use one. You can set to 'none' to disable this check.
+# @param cmdrunner_checksum Checksum for the cmdrunner .jar.
+# @param cmdrunner_version Version of cmdrunner to use. This should generally be left as default.
+# @param download_url Download URL for Jmeter.
+# @param enable_server Whether to enable the server. Replaces the previous method of declaring `class { 'jmeter::server': }`
+# @param java_version Java version to install.
+# @param jdk_pkg Name for the jdk package.
+# @param jmeter_version Sets version of jmeter to install. Note that 3.x requires Java v8.
+# @param jmeter_checksum Checksum for the Jmeter binary.
+# @param manage_java Whether to ensure that java is installed.
+# @param plugin_manager_checksum Checksum for the plugin manager download.
+# @param plugin_manager_install Whether or not to install the plugin manager.
+# @param plugin_manager_url Download URL for both the plugin manager and command runner. Note, this redirects, and part of the path has the
+#  package name appended and is built dynamically in jmeter::install.
+# @param plugin_manager_version Sets the version of the plugin manager to install.
 # @param plugins [Optional[Hash]] An optional hash of plugins to install via the plugin manager.
 class jmeter (
-  $enable_server           = false,
-  $bind_ip                 = '0.0.0.0',
-  $jmeter_version          = '3.2',
-  $jmeter_checksum         = '0a4aa15b39bd18e966948cde559dc82360326125',
-  $checksum_type           = 'sha1',
-  $plugin_manager_install  = false,
-  $plugin_manager_version  = '0.13',
-  $cmdrunner_version       = '2.0',
-  $cmdrunner_checksum      = '06ecaa09961e3d7bab009fed4fd6d34db81fa830',
-  $plugins                 = undef,
-  $download_url            = 'http://archive.apache.org/dist/jmeter/binaries/',
-  $plugin_manager_url      = 'http://search.maven.org/remotecontent?filepath=kg/apc/',
-  $plugin_manager_checksum = 'e80c003adb58cf152f861fdce398e0e76c3593da',
-  $java_version            = $jmeter::params::java_version,
-  $manage_java             = true,
-  $jdk_pkg                 = $jmeter::params::jdk_pkg
+  Boolean $enable_server                                         = false,
+  Stdlib::Compat::Ip_address $bind_ip                            = '0.0.0.0',
+  String $jmeter_version                                         = '3.2',
+  String $jmeter_checksum                                        = '0a4aa15b39bd18e966948cde559dc82360326125',
+  String $checksum_type                                          = 'sha1',
+  Boolean $plugin_manager_install                                = false,
+  String $plugin_manager_version                                 = '0.13',
+  String $cmdrunner_version                                      = '2.0',
+  String $cmdrunner_checksum                                     = '06ecaa09961e3d7bab009fed4fd6d34db81fa830',
+  Optional[Hash] $plugins                                        = undef,
+  Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl] $download_url       = 'http://archive.apache.org/dist/jmeter/binaries/',
+  Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl] $plugin_manager_url = 'http://search.maven.org/remotecontent?filepath=kg/apc/',
+  String $plugin_manager_checksum                                = 'e80c003adb58cf152f861fdce398e0e76c3593da',
+  String $java_version                                           = $jmeter::params::java_version,
+  Boolean $manage_java                                           = true,
+  String $jdk_pkg                                                = $jmeter::params::jdk_pkg
 ) inherits jmeter::params {
 
   Exec { path => '/bin:/usr/bin:/usr/sbin' }
 
-  validate_legacy('Optional[Boolean]', 'validate_bool', $plugin_manager_install)
-  # It looks like archive module already validates the URI itself
-  validate_legacy('Optional[String]', 'validate_re', $download_url, ['.'])
-  validate_legacy('Optional[String]', 'validate_re', $plugin_manager_url, ['.'])
-  validate_legacy('Optional[Boolean]', 'validate_bool', $manage_java)
-  validate_legacy('Optional[Boolean]', 'validate_bool', $enable_server)
-
-  contain ::jmeter::install
+  contain jmeter::install
 
   if $enable_server {
-    contain ::jmeter::server
+    contain jmeter::server
 
-    Class['::jmeter::install']
-    ~> Class['::jmeter::server']
+    Class['jmeter::install']
+    ~> Class['jmeter::server']
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,22 +39,22 @@
 # @param plugin_manager_version Sets the version of the plugin manager to install.
 # @param plugins [Optional[Hash]] An optional hash of plugins to install via the plugin manager.
 class jmeter (
-  Boolean $enable_server                                         = false,
-  Stdlib::Compat::Ip_address $bind_ip                            = '0.0.0.0',
-  String $jmeter_version                                         = '3.2',
-  String $jmeter_checksum                                        = '0a4aa15b39bd18e966948cde559dc82360326125',
-  String $checksum_type                                          = 'sha1',
-  Boolean $plugin_manager_install                                = false,
-  String $plugin_manager_version                                 = '0.13',
-  String $cmdrunner_version                                      = '2.0',
-  String $cmdrunner_checksum                                     = '06ecaa09961e3d7bab009fed4fd6d34db81fa830',
-  Optional[Hash] $plugins                                        = undef,
-  Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl] $download_url       = 'http://archive.apache.org/dist/jmeter/binaries/',
-  Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl] $plugin_manager_url = 'http://search.maven.org/remotecontent?filepath=kg/apc/',
-  String $plugin_manager_checksum                                = 'e80c003adb58cf152f861fdce398e0e76c3593da',
-  String $java_version                                           = $jmeter::params::java_version,
-  Boolean $manage_java                                           = true,
-  String $jdk_pkg                                                = $jmeter::params::jdk_pkg
+  Boolean $enable_server              = false,
+  Stdlib::Compat::Ip_address $bind_ip = '0.0.0.0',
+  String $jmeter_version              = '3.2',
+  String $jmeter_checksum             = '0a4aa15b39bd18e966948cde559dc82360326125',
+  String $checksum_type               = 'sha1',
+  Boolean $plugin_manager_install     = false,
+  String $plugin_manager_version      = '0.13',
+  String $cmdrunner_version           = '2.0',
+  String $cmdrunner_checksum          = '06ecaa09961e3d7bab009fed4fd6d34db81fa830',
+  Optional[Hash] $plugins             = undef,
+  Stdlib::HTTPUrl $download_url       = 'http://archive.apache.org/dist/jmeter/binaries/',
+  Stdlib::HTTPUrl $plugin_manager_url = 'http://search.maven.org/remotecontent?filepath=kg/apc/',
+  String $plugin_manager_checksum     = 'e80c003adb58cf152f861fdce398e0e76c3593da',
+  String $java_version                = $jmeter::params::java_version,
+  Boolean $manage_java                = true,
+  String $jdk_pkg                     = $jmeter::params::jdk_pkg
 ) inherits jmeter::params {
 
   Exec { path => '/bin:/usr/bin:/usr/sbin' }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,3 +1,4 @@
+# @api private
 # jmeter::install
 #
 # @summary This class installs JMeter (and, optionally, the plugin manager), from tarball. It also handles installing plugins.
@@ -7,28 +8,28 @@ class jmeter::install {
   assert_private()
 
   # Get rid of trailing slashes, as they mess up the redirect.
-  $download_url           = regsubst($::jmeter::download_url, '/$', '')
-  $plugin_manager_url     = regsubst($::jmeter::plugin_manager_url, '/$', '')
+  $download_url           = regsubst($jmeter::download_url, '/$', '')
+  $plugin_manager_url     = regsubst($jmeter::plugin_manager_url, '/$', '')
 
   $base_dir = '/usr/share'
   $lib_dir  = "${base_dir}/jmeter/lib"
   $ext_dir  = "${lib_dir}/ext"
 
-  if $::jmeter::manage_java {
-    ensure_packages($::jmeter::jdk_pkg)
+  if $jmeter::manage_java {
+    ensure_packages($jmeter::jdk_pkg)
   }
 
   ensure_packages(['unzip', 'wget'])
 
-  $jmeter_filename = "apache-jmeter-${::jmeter::jmeter_version}"
+  $jmeter_filename = "apache-jmeter-${jmeter::jmeter_version}"
   archive { "/tmp/${jmeter_filename}.tgz":
     source        => "${download_url}/${jmeter_filename}.tgz",
     extract       => true,
     extract_path  => $base_dir,
     creates       => "${base_dir}/${jmeter_filename}",
     cleanup       => true,
-    checksum      => $::jmeter::jmeter_checksum,
-    checksum_type => $::jmeter::checksum_type,
+    checksum      => $jmeter::jmeter_checksum,
+    checksum_type => $jmeter::checksum_type,
   }
 
   file { "${base_dir}/jmeter":
@@ -50,29 +51,29 @@ class jmeter::install {
   # need to be kept up-to-date.
   #
 
-  if $::jmeter::plugin_manager_install {
+  if $jmeter::plugin_manager_install {
 
-    $plugin_manager_filename = "jmeter-plugins-manager-${::jmeter::plugin_manager_version}.jar"
+    $plugin_manager_filename = "jmeter-plugins-manager-${jmeter::plugin_manager_version}.jar"
 
     archive { "${ext_dir}/${plugin_manager_filename}":
-      source        => "${plugin_manager_url}/jmeter-plugins-manager/${::jmeter::plugin_manager_version}/${plugin_manager_filename}",
+      source        => "${plugin_manager_url}/jmeter-plugins-manager/${jmeter::plugin_manager_version}/${plugin_manager_filename}",
       creates       => "${ext_dir}/${plugin_manager_filename}",
       require       => File["${base_dir}/jmeter"],
       cleanup       => false,
-      checksum      => $::jmeter::plugin_manager_checksum,
-      checksum_type => $::jmeter::checksum_type,
+      checksum      => $jmeter::plugin_manager_checksum,
+      checksum_type => $jmeter::checksum_type,
     }
 
     # These next steps are necessary to be able to non-interactively install plugins
-    $cmdrunner_filename = "cmdrunner-${::jmeter::cmdrunner_version}.jar"
+    $cmdrunner_filename = "cmdrunner-${jmeter::cmdrunner_version}.jar"
 
     archive { "${lib_dir}/${cmdrunner_filename}":
-      source        => "${plugin_manager_url}/cmdrunner/${::jmeter::cmdrunner_version}/${cmdrunner_filename}",
+      source        => "${plugin_manager_url}/cmdrunner/${jmeter::cmdrunner_version}/${cmdrunner_filename}",
       creates       => "${lib_dir}/${cmdrunner_filename}",
       require       => File["${base_dir}/jmeter"],
       cleanup       => false,
-      checksum      => $::jmeter::cmdrunner_checksum,
-      checksum_type => $::jmeter::checksum_type,
+      checksum      => $jmeter::cmdrunner_checksum,
+      checksum_type => $jmeter::checksum_type,
     }
 
     exec { 'install_cmdrunner':
@@ -83,7 +84,7 @@ class jmeter::install {
 
   }
 
-  if $::jmeter::plugins {
-    create_resources(jmeter_plugin, $::jmeter::plugins)
+  if $jmeter::plugins {
+    create_resources(jmeter_plugin, $jmeter::plugins)
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,10 +3,10 @@
 # @summary This class contains OS-specific parameters for jmeter
 class jmeter::params {
 
-  case $::osfamily {
+  case $facts['os']['family'] {
     'Debian' : {
       $init_template = 'jmeter/jmeter-init.erb'
-      if $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '16.04' {
+      if $facts['os']['name'] == 'Ubuntu' and $facts['os']['release']['full'] == '16.04' {
         $java_version = '8'
         $service_provider = systemd
       } else {
@@ -17,7 +17,7 @@ class jmeter::params {
     }
     'RedHat' : {
 
-      if versioncmp($::operatingsystemmajrelease, '7') >= 0  {
+      if versioncmp($facts['os']['release']['major'], '7') >= 0  {
         # TODO: add systemd stuff here
         $service_provider = systemd
         $init_template = 'jmeter/jmeter-init.redhat.erb'
@@ -32,7 +32,7 @@ class jmeter::params {
 
     }
     default: {
-      fail("Module ${module_name} is not supported on ${::operatingsystem}")
+      fail("Module ${module_name} is not supported on ${facts['os']['name']}")
     }
   }
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,14 +1,15 @@
+# @api private
 # jmeter::server
 #
-# @summary This class configures the server component of JMeter. Private class.
+# @summary This class configures the server component of JMeter.
 #
 class jmeter::server {
 
   assert_private()
 
-  $bind_ip = $::jmeter::bind_ip
+  $bind_ip = $jmeter::bind_ip
 
-  $init_template = $::jmeter::params::init_template
+  $init_template = $jmeter::params::init_template
 
   file { '/etc/init.d/jmeter':
     content => template($init_template),

--- a/metadata.json
+++ b/metadata.json
@@ -17,19 +17,24 @@
       "version_requirement": ">= 1.3.0 < 2.0.0"
     }
   ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.7.1 < 6.0.0"
+    }
+  ],
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "5.0",
         "6.0",
-        "7,0"
+        "7.0",
+        "8.0"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5.0",
         "6.0",
         "7.0"
       ]
@@ -44,10 +49,8 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04",
         "14.04",
-        "12.04",
-        "10.04"
+        "16.04"
       ]
     }
   ]

--- a/spec/acceptance/nodesets/ubuntu-1604-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-1604-x64.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  ubuntu-1604-x64:
+    roles:
+      - agent
+      - default
+    platform: ubuntu-16.04-amd64
+    hypervisor: vagrant
+    box: puppetlabs/ubuntu-16.04-64-nocm
+CONFIG:
+  type: foss

--- a/spec/classes/jmeter_spec.rb
+++ b/spec/classes/jmeter_spec.rb
@@ -8,99 +8,117 @@ describe 'jmeter' do
     @cmdrunner_version = '2.0'
   end
 
-  let :facts do
-    {
-      :osfamily => 'Debian',
-      :operatingsystem => 'Ubuntu',
-      :operatingsystemrelease => '16.04'
-    }
-  end
-
-  describe 'with defaults' do
-    it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_class('jmeter') }
-    it { is_expected.to contain_class('jmeter::install') }
-    it { is_expected.not_to contain_class('jmeter::server') }
-  end
-
-  # This is a private class, so easiest to test directly in the class spec.
-  context "jmeter::install" do
-    let :facts do
+  context 'on unsupported distributions' do
+    let(:facts) do
       {
-        :osfamily => 'Debian',
-        :operatingsystem => 'Ubuntu',
-        :operatingsystemrelease => '16.04'
+        os: { name: 'Unsupported', family: 'Unsupported' }
       }
     end
 
-    it do
-      is_expected.to contain_archive("/tmp/apache-jmeter-#{@jmeter_version}.tgz").with(
-        'source' => "http://archive.apache.org/dist/jmeter/binaries/apache-jmeter-#{@jmeter_version}.tgz"
-      )
-    end
-    it do
-      is_expected.to contain_file('/usr/share/jmeter').with( 
-        ensure: 'link'   
-      )
-    end
-    it do
-      is_expected.to contain_package('openjdk-8-jre-headless')
-    end
-
-    context "With plugin_manager_install set" do
-      let(:params) { { plugin_manager_install: true } }
-      it do
-        is_expected.to contain_archive("/usr/share/jmeter/lib/ext/jmeter-plugins-manager-#{@plugin_manager_version}.jar").with(
-          'source' => "http://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-manager/#{@plugin_manager_version}/jmeter-plugins-manager-#{@plugin_manager_version}.jar",
-          'creates' => "/usr/share/jmeter/lib/ext/jmeter-plugins-manager-#{@plugin_manager_version}.jar",
-          'cleanup' => :false
-        )
-      end
-      it do
-        is_expected.to contain_archive("/usr/share/jmeter/lib/cmdrunner-#{@cmdrunner_version}.jar").with(
-          'source'  => "http://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/#{@cmdrunner_version}/cmdrunner-#{@cmdrunner_version}.jar",
-          'creates' => "/usr/share/jmeter/lib/cmdrunner-#{@cmdrunner_version}.jar",
-          'cleanup' => :false
-        )
-      end
-      it do
-        is_expected.to contain_exec('install_cmdrunner').with(
-          'command' => "java -cp /usr/share/jmeter/lib/ext/jmeter-plugins-manager-#{@plugin_manager_version}.jar org.jmeterplugins.repository.PluginManagerCMDInstaller",
-          'creates' => '/usr/share/jmeter/bin/PluginsManagerCMD.sh'
-        )
-      end
-    end
-
-    context "With plugins ensured" do
-      let(:params) do
-        {
-          plugins: {
-            'foo'    => {'ensure' => 'present'},
-            'woozle' => {'ensure' => 'absent'}
-          }
-        }
-      end
-      it do
-        is_expected.to contain_jmeter_plugin('foo').with(
-          'ensure' => 'present',
-        )
-      end
-      it do
-        is_expected.to contain_jmeter_plugin('woozle').with(
-          'ensure' => 'absent',
-        )
-      end
-    end
-
-    context 'With server enabled' do
-      let(:params) { { enable_server: true } }
-
-      it { is_expected.to contain_class('jmeter::server') }
-      it do
-        is_expected.to contain_service('jmeter').with(
-          { 'ensure' => 'running', 'enable' => 'true' }
-        )
-      end
+    it 'we fail' do
+      expect { catalogue }.to raise_error(Puppet::Error, %r{Module jmeter is not supported on Unsupported})
     end
   end
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+
+      has_systemd = (
+        (facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'].to_i >= 7) ||
+        (facts[:os]['family'] == 'Debian' && facts[:os]['release']['full'] == '16.04')
+      )
+
+      describe 'with defaults' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('jmeter') }
+        it { is_expected.to contain_class('jmeter::install') }
+        it { is_expected.not_to contain_class('jmeter::server') }
+      end
+    
+      # This is a private class, so easiest to test directly in the class spec.
+      context "jmeter::install" do
+        it do
+          is_expected.to contain_archive("/tmp/apache-jmeter-#{@jmeter_version}.tgz").with(
+            'source' => "http://archive.apache.org/dist/jmeter/binaries/apache-jmeter-#{@jmeter_version}.tgz"
+          )
+        end
+        it do
+          is_expected.to contain_file('/usr/share/jmeter').with( 
+            ensure: 'link'   
+          )
+        end
+				if facts[:os]['family'] == 'Debian'
+					if facts[:os]['release']['major'] == '16.04'
+        		it { is_expected.to contain_package('openjdk-8-jre-headless') }
+					else
+        		it { is_expected.to contain_package('openjdk-7-jre-headless') }
+					end
+				end
+				if facts[:os]['family'] == 'RedHat'
+					if facts[:os]['release']['major'] == '7'
+        		it { is_expected.to contain_package('java-1.8.0-openjdk') }
+					else
+        		it { is_expected.to contain_package('java-1.7.0-openjdk') }
+					end
+				end
+    
+        context "With plugin_manager_install set" do
+          let(:params) { { plugin_manager_install: true } }
+          it do
+            is_expected.to contain_archive("/usr/share/jmeter/lib/ext/jmeter-plugins-manager-#{@plugin_manager_version}.jar").with(
+              'source' => "http://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-manager/#{@plugin_manager_version}/jmeter-plugins-manager-#{@plugin_manager_version}.jar",
+              'creates' => "/usr/share/jmeter/lib/ext/jmeter-plugins-manager-#{@plugin_manager_version}.jar",
+              'cleanup' => :false
+            )
+          end
+          it do
+            is_expected.to contain_archive("/usr/share/jmeter/lib/cmdrunner-#{@cmdrunner_version}.jar").with(
+              'source'  => "http://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/#{@cmdrunner_version}/cmdrunner-#{@cmdrunner_version}.jar",
+              'creates' => "/usr/share/jmeter/lib/cmdrunner-#{@cmdrunner_version}.jar",
+              'cleanup' => :false
+            )
+          end
+          it do
+            is_expected.to contain_exec('install_cmdrunner').with(
+              'command' => "java -cp /usr/share/jmeter/lib/ext/jmeter-plugins-manager-#{@plugin_manager_version}.jar org.jmeterplugins.repository.PluginManagerCMDInstaller",
+              'creates' => '/usr/share/jmeter/bin/PluginsManagerCMD.sh'
+            )
+          end
+        end
+    
+        context "With plugins ensured" do
+          let(:params) do
+            {
+              plugins: {
+                'foo'    => {'ensure' => 'present'},
+                'woozle' => {'ensure' => 'absent'}
+              }
+            }
+          end
+          it do
+            is_expected.to contain_jmeter_plugin('foo').with(
+              'ensure' => 'present',
+            )
+          end
+          it do
+            is_expected.to contain_jmeter_plugin('woozle').with(
+              'ensure' => 'absent',
+            )
+          end
+        end
+    
+        context 'With server enabled' do
+          let(:params) { { enable_server: true } }
+    
+          it { is_expected.to contain_class('jmeter::server') }
+          it do
+            is_expected.to contain_service('jmeter').with(
+              { 'ensure' => 'running', 'enable' => 'true' }
+            )
+          end
+        end
+      end
+    end
+	end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,3 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet-facts'
+include RspecPuppetFacts

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,34 +1,14 @@
 require 'beaker-rspec'
 require 'beaker/puppet_install_helper'
+require 'beaker/module_install_helper'
 
-UNSUPPORTED_PLATFORMS = ['windows', 'Darwin', 'Solaris']
+UNSUPPORTED_PLATFORMS = [].freeze
 
-unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
-
-  run_puppet_install_helper
-
-  hosts.each do |host|
-    # for now we have to use unreleased versions of stdlib and tea for testing
-    apply_manifest_on(host, 'package { "git": }')
-    environmentpath = host.puppet['environmentpath']
-    environmentpath = environmentpath.split(':').first if environmentpath
-
-    on host, puppet('module install puppetlabs-stdlib')
-    on host, puppet('module install puppet-archive')
-  end
-end
+run_puppet_install_helper
+install_module
+install_module_dependencies
 
 RSpec.configure do |c|
-  # Project root
-  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-
   # Readable test descriptions
   c.formatter = :documentation
-
-  # Configure all nodes in nodeset
-  c.before :suite do
-    hosts.each do |host|
-      copy_module_to(host, :source => proj_root, :module_name => 'jmeter')
-    end
-  end
 end


### PR DESCRIPTION
Implemented in this PR:
- Switch to Puppet 4 data types
- Improve puppet-strings docs
- Switch the spec tests to use rspec-puppet-facts
- Drop support for older versions of Puppet, older versions of certain OSes (though it should continue to run on earlier versions of those supported OSes, at least for now).
- Switch back to `foo::bar` vs `::foo::bar` syntax, which is preferred under Puppet >= 4.
- Update acceptance tests to use module_install_helper

Additionally, I would like to submit a couple more PRs that would run Jmeter as a (configurable) non-root user by default, and drop down a systemd unit file on systems that support systemd.