### PR TITLE
Breaking: Run as unprivileged user, version updates

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,6 @@ fixtures:
   forge_modules:
     stdlib: 'puppetlabs/stdlib'
     archive: 'puppet-archive'
+    systemd: 'camptocamp-systemd'
   symlinks:
     jmeter: "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@
 [![Puppet Forge](https://img.shields.io/puppetforge/v/dduvnjak/jmeter.svg)](https://forge.puppet.com/dduvnjak/jmeter)
 [![Puppet Forge - downloads](https://img.shields.io/puppetforge/dt/dduvnjak/jmeter.svg)](https://forge.puppetlabs.com/dduvnjak/jmeter)
 
-This class installs the latest version of JMeter (currently v3.2) from apache.org. If you set the `enable_server` parameter, an init script will be installed, the service enabled, and JMeter will be started in server mode listening on the default port.
+This class installs JMeter from apache.org. If you set the `enable_server` parameter, a service will be configured and enabled, and JMeter will be started in server mode listening on the default port.
 
 `jmeter` can optionally install the plugin manager, which allows you to install additional plugins.
 
 The init script is based on the one available at https://gist.github.com/2830209.
 
-Note: If you are using 3.x (the default version), you will need to have at least Java 8 installed.
+Note: If you are using 3.x, you will need to have at least Java 8 installed. If the version is not set, the module will try to choose an appropriate version for you.
 
 Requirements
 ------------
 
-This module requires Puppet 4.7.1 or higher, as well as the stdlib and
-puppet-archive modules.
+This module requires Puppet 4.7.1 or higher, as well as the stdlib and puppet-archive modules. On systems that use systemd,
+(Ubuntu >= 16.04, CentOS >= 7), [camptocamp/systemd](https://forge.puppet.com/camptocamp/systemd) is a soft dependency.
 
 Basic usage
 -----------
@@ -28,7 +28,7 @@ Install JMeter:
 Install JMeter v3.x, plugin manager ([JMeterPlugins](http://jmeter-plugins.org/), and enable the most recent version of plugins 'foo' and 'bar'. 
 
     class { 'jmeter':
-      jmeter_version         => '3.2',
+      jmeter_version         => '3.3',
       plugin_manager_install => true,
       plugins                => {
         'foo' => { ensure => present },

--- a/lib/puppet/provider/jmeter_plugin/jmeterplugins.rb
+++ b/lib/puppet/provider/jmeter_plugin/jmeterplugins.rb
@@ -8,24 +8,16 @@ DESC
 
   def self.get_plugins
 
-    plugins = Hash.new
+    plugins = {}
 
-    jmeterplugins('status').split(/\n/).map do |line|
-
-      if line =~ /\[.*\]/
-        line = line.strip()
-        line = line.tr('[]', '')
-        chunks = line.split(', ')
-        chunks.each do |chunk|
-          name, version = chunk.split('=')
-          plugins[name] = version
-        end
-      elsif line =~ /^ERROR StatusLogger/
-        # Harmless
-        next
-      else
-        raise Puppet::Error, "Cannot parse invalid plugins line: #{line}"
-      end
+    lines = jmeterplugins('status').split(%r{\n})
+    raise Puppet::Error, 'Cannot get plugin status' unless lines.last =~ %r{\[.*\]}
+    line = lines.last.strip
+    line = line.tr('[]', '')
+    chunks = line.split(', ')
+    chunks.each do |chunk|
+      name, version = chunk.split('=')
+      plugins[name] = version
     end
     plugins
   end

--- a/lib/puppet/provider/jmeter_plugin/jmeterplugins.rb
+++ b/lib/puppet/provider/jmeter_plugin/jmeterplugins.rb
@@ -6,7 +6,7 @@ DESC
 
   has_command(:jmeterplugins, '/usr/share/jmeter/bin/PluginsManagerCMD.sh')
 
-  def self.get_plugins
+  def self.plugins
     plugins = {}
 
     lines = jmeterplugins('status').split(%r{\n})
@@ -23,7 +23,7 @@ DESC
 
   def self.instances
     resources = []
-    get_plugins.map do |name, _versions|
+    plugins.map do |name, _versions|
       plugin = {
         ensure: :present,
         name: name
@@ -36,7 +36,7 @@ DESC
   def self.prefetch(resources)
     plugins = instances
     resources.keys.each do |name|
-      if provider = plugins.find { |plugin| plugin.name == name }
+      if (provider = plugins.find { |plugin| plugin.name == name })
         resources[name].provider = provider
       end
     end

--- a/lib/puppet/provider/jmeter_plugin/jmeterplugins.rb
+++ b/lib/puppet/provider/jmeter_plugin/jmeterplugins.rb
@@ -7,7 +7,6 @@ DESC
   has_command(:jmeterplugins, '/usr/share/jmeter/bin/PluginsManagerCMD.sh')
 
   def self.get_plugins
-
     plugins = {}
 
     lines = jmeterplugins('status').split(%r{\n})
@@ -23,11 +22,11 @@ DESC
   end
 
   def self.instances
-    resources = Array.new
-    get_plugins.collect do |name, versions|
+    resources = []
+    get_plugins.map do |name, _versions|
       plugin = {
-        :ensure => :present,
-        :name   => name,
+        ensure: :present,
+        name: name
       }
       resources << new(plugin) if plugin[:name]
     end
@@ -37,7 +36,7 @@ DESC
   def self.prefetch(resources)
     plugins = instances
     resources.keys.each do |name|
-      if provider = plugins.find{ |plugin| plugin.name == name }
+      if provider = plugins.find { |plugin| plugin.name == name }
         resources[name].provider = provider
       end
     end
@@ -58,5 +57,4 @@ DESC
   end
 
   # may need to flush also
-
 end

--- a/lib/puppet/type/jmeter_plugin.rb
+++ b/lib/puppet/type/jmeter_plugin.rb
@@ -1,5 +1,5 @@
 Puppet::Type.newtype(:jmeter_plugin) do
-  @doc = "Manage jmeter plugins."
+  @doc = 'Manage jmeter plugins.'
 
   ensurable do
     desc 'Ensure that a plugin is installed or absent. Hope to support specifying version in the future'
@@ -12,9 +12,8 @@ Puppet::Type.newtype(:jmeter_plugin) do
     end
   end
 
-  newparam(:name, :namevar => true) do
-    desc "Name of the plugin."
-    newvalues(/^\S+$/)
+  newparam(:name, namevar: true) do
+    desc 'Name of the plugin.'
+    newvalues(%r{^\S+$})
   end
-
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,7 @@
 #   }
 #
 # @param bind_ip IP address to bind to. Defaults to '0.0.0.0' (all interfaces). Replaces `jmeter::server::server_ip`
+# @param bind_port Port for server to use.
 # @param checksum_type Checksum type to use for all download commands that use one. You can set to 'none' to disable this check.
 # @param cmdrunner_checksum Checksum for the cmdrunner .jar.
 # @param cmdrunner_version Version of cmdrunner to use. This should generally be left as default.
@@ -32,6 +33,8 @@
 # @param jmeter_version Sets version of jmeter to install. Note that 3.x requires Java v8.
 # @param jmeter_checksum Checksum for the Jmeter binary.
 # @param manage_java Whether to ensure that java is installed.
+# @param jmeter_user User to run jmeter under
+# @param jmeter_group Group to run jmeter under
 # @param plugin_manager_checksum Checksum for the plugin manager download.
 # @param plugin_manager_install Whether or not to install the plugin manager.
 # @param plugin_manager_url Download URL for both the plugin manager and command runner. Note, this redirects, and part of the path has the
@@ -41,17 +44,20 @@
 class jmeter (
   Boolean $enable_server              = false,
   Stdlib::Compat::Ip_address $bind_ip = '0.0.0.0',
-  String $jmeter_version              = '3.2',
-  String $jmeter_checksum             = '0a4aa15b39bd18e966948cde559dc82360326125',
+  Integer[0,65535] $bind_port         = 1099,
+  String $jmeter_version              = $jmeter::params::jmeter_version,
+  String $jmeter_checksum             = $jmeter::params::jmeter_checksum,
+  String $jmeter_user                 = 'jmeter',
+  String $jmeter_group                = 'jmeter',
   String $checksum_type               = 'sha1',
   Boolean $plugin_manager_install     = false,
-  String $plugin_manager_version      = '0.13',
+  String $plugin_manager_version      = '0.16',
+  String $plugin_manager_checksum     = 'a6ea7eccea25ae80e76c72ac06695f14c3bef010',
   String $cmdrunner_version           = '2.0',
   String $cmdrunner_checksum          = '06ecaa09961e3d7bab009fed4fd6d34db81fa830',
   Optional[Hash] $plugins             = undef,
   Stdlib::HTTPUrl $download_url       = 'http://archive.apache.org/dist/jmeter/binaries/',
   Stdlib::HTTPUrl $plugin_manager_url = 'http://search.maven.org/remotecontent?filepath=kg/apc/',
-  String $plugin_manager_checksum     = 'e80c003adb58cf152f861fdce398e0e76c3593da',
   String $java_version                = $jmeter::params::java_version,
   Boolean $manage_java                = true,
   String $jdk_pkg                     = $jmeter::params::jdk_pkg
@@ -63,9 +69,11 @@ class jmeter (
 
   if $enable_server {
     contain jmeter::server
+    contain jmeter::service
 
     Class['jmeter::install']
-    ~> Class['jmeter::server']
+    -> Class['jmeter::server']
+    ~> Class['jmeter::service']
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,7 +40,7 @@
 # @param plugin_manager_url Download URL for both the plugin manager and command runner. Note, this redirects, and part of the path has the
 #  package name appended and is built dynamically in jmeter::install.
 # @param plugin_manager_version Sets the version of the plugin manager to install.
-# @param plugins [Optional[Hash]] An optional hash of plugins to install via the plugin manager.
+# @param plugins An optional hash of plugins to install via the plugin manager.
 class jmeter (
   Boolean $enable_server              = false,
   Stdlib::Compat::Ip_address $bind_ip = '0.0.0.0',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,35 +4,40 @@
 class jmeter::params {
 
   case $facts['os']['family'] {
-    'Debian' : {
+    'Debian': {
       $init_template = 'jmeter/jmeter-init.erb'
       if $facts['os']['name'] == 'Ubuntu' and $facts['os']['release']['full'] == '16.04' {
-        $java_version = '8'
-        $service_provider = systemd
+        $java_version     = '8'
+        $jmeter_version   = '3.3'
+        $service_provider = 'systemd'
       } else {
-        $java_version = '7'
-        $service_provider = debian
+        $java_version     = '7'
+        $jmeter_version   = '2.9'
+        $service_provider = 'debian'
       }
       $jdk_pkg       = "openjdk-${java_version}-jre-headless"
     }
-    'RedHat' : {
-
+    'RedHat': {
+      $init_template = 'jmeter/jmeter-init.redhat.erb'
       if versioncmp($facts['os']['release']['major'], '7') >= 0  {
-        # TODO: add systemd stuff here
-        $service_provider = systemd
-        $init_template = 'jmeter/jmeter-init.redhat.erb'
-        $java_version  = '8'
+        $jmeter_version   = '3.3'
+        $service_provider = 'systemd'
+        $java_version     = '8'
       } else {
-        $service_provider = redhat
-        $init_template = 'jmeter/jmeter-init.redhat.erb'
-        $java_version  = '7'
+        $java_version     = '7'
+        $jmeter_version   = '2.9'
+        $service_provider = 'redhat'
       }
-
       $jdk_pkg       = "java-1.${java_version}.0-openjdk"
-
     }
     default: {
       fail("Module ${module_name} is not supported on ${facts['os']['name']}")
     }
+  }
+
+  if $jmeter_version == '2.9' {
+    $jmeter_checksum = '0f62c5173fc0bd46f4fe4e850ca8906e612fdaf9'
+  } elsif $jmeter_version == '3.3' {
+    $jmeter_checksum = 'aa08f999dbc89f171c78556ed5e93379c8b53b1d'
   }
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -7,30 +7,20 @@ class jmeter::server {
 
   assert_private()
 
-  $bind_ip = $jmeter::bind_ip
+  $jmeter_user      = $jmeter::jmeter_user
+  $jmeter_group     = $jmeter::jmeter_group
 
-  $init_template = $jmeter::params::init_template
-
-  file { '/etc/init.d/jmeter':
-    content => template($init_template),
-    owner   => root,
-    group   => root,
-    mode    => '0755',
-    notify  => Service['jmeter'],
+  user { $jmeter_user:
+    gid => $jmeter_group,
+  }
+  group { $jmeter_group:
+    ensure => present,
   }
 
-  if $::osfamily == 'debian' {
-    exec { 'jmeter-update-rc':
-      command     => '/usr/sbin/update-rc.d jmeter defaults',
-      subscribe   => File['/etc/init.d/jmeter'],
-      refreshonly => true,
-    }
-  }
-
-  service { 'jmeter':
-    ensure   => running,
-    enable   => true,
-    require  => File['/etc/init.d/jmeter'],
-    provider => $jmeter::params::service_provider,
+  file { '/var/log/jmeter':
+    ensure => directory,
+    mode   => '0750',
+    owner  => $jmeter_user,
+    group  => $jmeter_group,
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,0 +1,38 @@
+# @api private
+# jmeter::service
+#
+# @summary This class configures the service for `jmeter::server`.
+#
+class jmeter::service {
+
+  assert_private()
+
+  $bind_ip          = $jmeter::bind_ip
+  $bind_port        = $jmeter::bind_port
+  $jmeter_user      = $jmeter::jmeter_user
+  $init_template    = $jmeter::params::init_template
+  $service_provider = $jmeter::params::service_provider
+
+  if $service_provider == 'systemd' {
+    systemd::unit_file { 'jmeter.service':
+      content => template('jmeter/jmeter.service.erb'),
+    }
+  } else {
+    file { '/etc/init.d/jmeter':
+      content => template($init_template),
+      owner   => root,
+      group   => root,
+      mode    => '0755',
+      notify  => Service['jmeter'],
+    }
+  }
+
+  ~> service { 'jmeter':
+    ensure => running,
+    enable => true,
+  }
+
+  if $service_provider == 'systemd' {
+    Class['systemd'] -> Service['jmeter']
+  }
+}

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -1,19 +1,19 @@
 require 'spec_helper_acceptance'
 
-describe 'jmeter class:', :unless => UNSUPPORTED_PLATFORMS.include?(fact('os.family')) do
+describe 'jmeter class:', unless: UNSUPPORTED_PLATFORMS.include?(fact('os.family')) do
   case fact('os.family')
   when 'RedHat'
-    if fact('os.release.major').to_i >= 7
-      jmeter_version = '3.3'
-    else
-      jmeter_version = '2.9'
-    end
+    jmeter_version = if fact('os.release.major').to_i >= 7
+                       '3.3'
+                     else
+                       '2.9'
+                     end
   when 'Debian'
-    if fact('os.name') == 'Ubuntu' and fact('os.release.full') == '16.04'
-      jmeter_version = '3.3'
-    else
-      jmeter_version = '2.9'
-    end
+    jmeter_version = if fact('os.name') == 'Ubuntu' && fact('os.release.full') == '16.04'
+                       '3.3'
+                     else
+                       '2.9'
+                     end
   end
 
   context 'base class' do
@@ -21,11 +21,11 @@ describe 'jmeter class:', :unless => UNSUPPORTED_PLATFORMS.include?(fact('os.fam
       pp = "class { '::jmeter': }"
 
       # Apply twice to ensure no errors the second time.
-      apply_manifest(pp, :catch_failures => true) do |r|
-        expect(r.stderr).not_to match(/error/i)
+      apply_manifest(pp, catch_failures: true) do |r|
+        expect(r.stderr).not_to match(%r{error}i)
       end
-      apply_manifest(pp, :catch_failures => true) do |r|
-        expect(r.stderr).not_to eq(/error/i)
+      apply_manifest(pp, catch_failures: true) do |r|
+        expect(r.stderr).not_to eq(%r{error}i)
 
         expect(r.exit_code).to be_zero
       end
@@ -37,7 +37,6 @@ describe 'jmeter class:', :unless => UNSUPPORTED_PLATFORMS.include?(fact('os.fam
     describe file('/usr/share/jmeter') do
       it { is_expected.to be_symlink }
     end
-
   end
 
   context 'with install plugin option' do
@@ -51,11 +50,11 @@ class { 'jmeter':
 }
       EOS
       # Apply twice to ensure no errors the second time.
-      apply_manifest(pp, :catch_failures => true) do |r|
-        expect(r.stderr).not_to match(/error/i)
+      apply_manifest(pp, catch_failures: true) do |r|
+        expect(r.stderr).not_to match(%r{error}i)
       end
-      apply_manifest(pp, :catch_failures => true) do |r|
-        expect(r.stderr).not_to eq(/error/i)
+      apply_manifest(pp, catch_failures: true) do |r|
+        expect(r.stderr).not_to eq(%r{error}i)
 
         expect(r.exit_code).to be_zero
       end
@@ -73,14 +72,13 @@ class { 'jmeter':
   end
 
   context 'jmeter::server class' do
-
     it 'sets up the service' do
       pp = <<-EOS
 class { 'jmeter':
   enable_server => true,
 }
       EOS
-      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, catch_failures: true)
     end
     describe service('jmeter') do
       it { is_expected.to be_enabled }

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -1,7 +1,20 @@
 require 'spec_helper_acceptance'
-require 'specinfra'
 
-describe 'jmeter class:', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+describe 'jmeter class:', :unless => UNSUPPORTED_PLATFORMS.include?(fact('os.family')) do
+  case fact('os.family')
+  when 'RedHat'
+    if fact('os.release.major').to_i >= 7
+      jmeter_version = '3.3'
+    else
+      jmeter_version = '2.9'
+    end
+  when 'Debian'
+    if fact('os.name') == 'Ubuntu' and fact('os.release.full') == '16.04'
+      jmeter_version = '3.3'
+    else
+      jmeter_version = '2.9'
+    end
+  end
 
   context 'base class' do
     it 'applies successfully' do
@@ -18,7 +31,7 @@ describe 'jmeter class:', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfami
       end
     end
 
-    describe file('/usr/share/apache-jmeter-3.2/lib') do
+    describe file("/usr/share/apache-jmeter-#{jmeter_version}/lib") do
       it { is_expected.to be_directory }
     end
     describe file('/usr/share/jmeter') do
@@ -48,10 +61,10 @@ class { 'jmeter':
       end
     end
 
-    describe file('/usr/share/apache-jmeter-3.2/lib/ext/jmeter-plugins-manager-0.13.jar') do
+    describe file("/usr/share/apache-jmeter-#{jmeter_version}/lib/ext/jmeter-plugins-manager-0.16.jar") do
       it { is_expected.to be_file }
     end
-    describe file('/usr/share/apache-jmeter-3.2/lib/cmdrunner-2.0.jar') do
+    describe file("/usr/share/apache-jmeter-#{jmeter_version}/lib/cmdrunner-2.0.jar") do
       it { is_expected.to be_file }
     end
     describe command('/usr/share/jmeter/bin/PluginsManagerCMD.sh status') do
@@ -73,7 +86,9 @@ class { 'jmeter':
       it { is_expected.to be_enabled }
       it { is_expected.to be_running }
     end
+
     describe port(1099) do
+      # This seems to fail, even with a sleep before it
       xit { is_expected.to be_listening }
     end
   end

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -18,17 +18,11 @@ describe 'jmeter class:', unless: UNSUPPORTED_PLATFORMS.include?(fact('os.family
 
   context 'base class' do
     it 'applies successfully' do
-      pp = "class { '::jmeter': }"
+      pp = "class { 'jmeter': }"
 
       # Apply twice to ensure no errors the second time.
-      apply_manifest(pp, catch_failures: true) do |r|
-        expect(r.stderr).not_to match(%r{error}i)
-      end
-      apply_manifest(pp, catch_failures: true) do |r|
-        expect(r.stderr).not_to eq(%r{error}i)
-
-        expect(r.exit_code).to be_zero
-      end
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
     end
 
     describe file("/usr/share/apache-jmeter-#{jmeter_version}/lib") do
@@ -50,14 +44,8 @@ class { 'jmeter':
 }
       EOS
       # Apply twice to ensure no errors the second time.
-      apply_manifest(pp, catch_failures: true) do |r|
-        expect(r.stderr).not_to match(%r{error}i)
-      end
-      apply_manifest(pp, catch_failures: true) do |r|
-        expect(r.stderr).not_to eq(%r{error}i)
-
-        expect(r.exit_code).to be_zero
-      end
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
     end
 
     describe file("/usr/share/apache-jmeter-#{jmeter_version}/lib/ext/jmeter-plugins-manager-0.16.jar") do
@@ -79,6 +67,7 @@ class { 'jmeter':
 }
       EOS
       apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
     end
     describe service('jmeter') do
       it { is_expected.to be_enabled }

--- a/spec/acceptance/nodesets/centos-6-x64.yml
+++ b/spec/acceptance/nodesets/centos-6-x64.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  centos-6-x64:
+    roles:
+      - agent
+      - default
+    platform: el-6-x86_64
+    hypervisor: vagrant
+    box: centos/6
+CONFIG:
+  type: foss

--- a/spec/classes/jmeter_spec.rb
+++ b/spec/classes/jmeter_spec.rb
@@ -30,7 +30,7 @@ describe 'jmeter' do
           java_package   = 'java-1.7.0-openjdk'
         end
       when 'Debian'
-        if facts[:os]['name'] == 'Ubuntu' and facts[:os]['release']['full'] == '16.04'
+        if facts[:os]['name'] == 'Ubuntu' && facts[:os]['release']['full'] == '16.04'
           jmeter_version = '3.3'
           java_package   = 'openjdk-8-jre-headless'
         else
@@ -51,24 +51,25 @@ describe 'jmeter' do
         it { is_expected.not_to contain_class('jmeter::server') }
         it { is_expected.not_to contain_class('jmeter::service') }
       end
-    
+
       # This is a private class, so easiest to test directly in the class spec.
-      context "jmeter::install" do
+      context 'jmeter::install' do
         it do
           is_expected.to contain_archive("/tmp/apache-jmeter-#{jmeter_version}.tgz").with(
             'source' => "http://archive.apache.org/dist/jmeter/binaries/apache-jmeter-#{jmeter_version}.tgz"
           )
         end
         it do
-          is_expected.to contain_file('/usr/share/jmeter').with( 
-            ensure: 'link'   
+          is_expected.to contain_file('/usr/share/jmeter').with(
+            ensure: 'link'
           )
         end
 
         it { is_expected.to contain_package(java_package) }
-    
-        context "With plugin_manager_install set" do
+
+        context 'With plugin_manager_install set' do
           let(:params) { { plugin_manager_install: true } }
+
           it do
             is_expected.to contain_archive("/usr/share/jmeter/lib/ext/jmeter-plugins-manager-#{@plugin_manager_version}.jar").with(
               'source' => "http://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-manager/#{@plugin_manager_version}/jmeter-plugins-manager-#{@plugin_manager_version}.jar",
@@ -90,36 +91,37 @@ describe 'jmeter' do
             )
           end
         end
-    
-        context "With plugins ensured" do
+
+        context 'With plugins ensured' do
           let(:params) do
             {
               plugins: {
-                'foo'    => {'ensure' => 'present'},
-                'woozle' => {'ensure' => 'absent'}
+                'foo'    => { 'ensure' => 'present' },
+                'woozle' => { 'ensure' => 'absent' }
               }
             }
           end
+
           it do
             is_expected.to contain_jmeter_plugin('foo').with(
-              'ensure' => 'present',
+              'ensure' => 'present'
             )
           end
           it do
             is_expected.to contain_jmeter_plugin('woozle').with(
-              'ensure' => 'absent',
+              'ensure' => 'absent'
             )
           end
         end
-    
+
         context 'With server enabled' do
           let(:params) { { enable_server: true } }
-    
+
           it { is_expected.to contain_class('jmeter::server') }
           it { is_expected.to contain_class('jmeter::service') }
           it do
             is_expected.to contain_service('jmeter').with(
-              { 'ensure' => 'running', 'enable' => 'true' }
+              'ensure' => 'running', 'enable' => 'true'
             )
           end
         end
@@ -177,8 +179,7 @@ describe 'jmeter' do
             end
           end
         end
-
       end
     end
-	end
+  end
 end

--- a/spec/classes/jmeter_spec.rb
+++ b/spec/classes/jmeter_spec.rb
@@ -71,22 +71,22 @@ describe 'jmeter' do
           let(:params) { { plugin_manager_install: true } }
 
           it do
-            is_expected.to contain_archive("/usr/share/jmeter/lib/ext/jmeter-plugins-manager-#{@plugin_manager_version}.jar").with(
-              'source' => "http://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-manager/#{@plugin_manager_version}/jmeter-plugins-manager-#{@plugin_manager_version}.jar",
-              'creates' => "/usr/share/jmeter/lib/ext/jmeter-plugins-manager-#{@plugin_manager_version}.jar",
+            is_expected.to contain_archive("/usr/share/jmeter/lib/ext/jmeter-plugins-manager-#{plugin_manager_version}.jar").with(
+              'source' => "http://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-manager/#{plugin_manager_version}/jmeter-plugins-manager-#{plugin_manager_version}.jar",
+              'creates' => "/usr/share/jmeter/lib/ext/jmeter-plugins-manager-#{plugin_manager_version}.jar",
               'cleanup' => :false
             )
           end
           it do
-            is_expected.to contain_archive("/usr/share/jmeter/lib/cmdrunner-#{@cmdrunner_version}.jar").with(
-              'source'  => "http://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/#{@cmdrunner_version}/cmdrunner-#{@cmdrunner_version}.jar",
-              'creates' => "/usr/share/jmeter/lib/cmdrunner-#{@cmdrunner_version}.jar",
+            is_expected.to contain_archive("/usr/share/jmeter/lib/cmdrunner-#{cmdrunner_version}.jar").with(
+              'source'  => "http://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/#{cmdrunner_version}/cmdrunner-#{cmdrunner_version}.jar",
+              'creates' => "/usr/share/jmeter/lib/cmdrunner-#{cmdrunner_version}.jar",
               'cleanup' => :false
             )
           end
           it do
             is_expected.to contain_exec('install_cmdrunner').with(
-              'command' => "java -cp /usr/share/jmeter/lib/ext/jmeter-plugins-manager-#{@plugin_manager_version}.jar org.jmeterplugins.repository.PluginManagerCMDInstaller",
+              'command' => "java -cp /usr/share/jmeter/lib/ext/jmeter-plugins-manager-#{plugin_manager_version}.jar org.jmeterplugins.repository.PluginManagerCMDInstaller",
               'creates' => '/usr/share/jmeter/bin/PluginsManagerCMD.sh'
             )
           end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -8,6 +8,9 @@ run_puppet_install_helper
 install_module
 install_module_dependencies
 
+# Additional modules for soft deps
+install_module_from_forge('camptocamp-systemd', '>= 1.0.0 < 2.0.0')
+
 RSpec.configure do |c|
   # Readable test descriptions
   c.formatter = :documentation

--- a/spec/unit/puppet/provider/jmeter_plugin/jmeterplugins.rb
+++ b/spec/unit/puppet/provider/jmeter_plugin/jmeterplugins.rb
@@ -8,11 +8,11 @@ end
 provider_class = Puppet::Type.type(:jmeter_plugin).provider(:jmeterplugins)
 
 describe provider_class do
-  before do
-    @resource = Puppet::Type::Jmeter_plugin.new(
-      name: 'foo'
-    )
-    @provider = provider_class.new(@resource)
+  let(:resource) do
+    Puppet::Type::Jmeter_plugin.new(name: 'foo')
+  end
+  let(:provider) do
+    provider_class.new(resource)
   end
 
   it 'returns instances' do
@@ -40,11 +40,11 @@ EOT
   end
 
   it 'calls jmeterplugins to create' do
-    @provider.expects(:jmeterplugins).with('install', 'foo')
-    @provider.create
+    provider.expects(:jmeterplugins).with('install', 'foo')
+    provider.create
   end
   it 'calls jmeterplugins to destroy' do
-    @provider.expects(:jmeterplugins).with('uninstall', 'foo')
-    @provider.destroy
+    provider.expects(:jmeterplugins).with('uninstall', 'foo')
+    provider.destroy
   end
 end

--- a/spec/unit/puppet/provider/jmeter_plugin/jmeterplugins.rb
+++ b/spec/unit/puppet/provider/jmeter_plugin/jmeterplugins.rb
@@ -8,14 +8,14 @@ end
 provider_class = Puppet::Type.type(:jmeter_plugin).provider(:jmeterplugins)
 
 describe provider_class do
-  before :each do
+  before do
     @resource = Puppet::Type::Jmeter_plugin.new(
-      {:name => 'foo'}
+      name: 'foo'
     )
     @provider = provider_class.new(@resource)
   end
 
-  it 'should return instances' do
+  it 'returns instances' do
     provider_class.expects(:jmeterplugins).with('status').returns <<-EOT
 INFO    2017-10-11 20:07:17.864 [org.jmet] (): Command is: status
 WARN    2017-10-11 20:07:17.963 [org.jmet] (): Found JAR conflict: /usr/share/apache-jmeter-2.9/lib/commons-jexl-2.1.1.jar and /usr/share/apache-jmeter-2.9/lib/commons-jexl-1.1.jar
@@ -39,13 +39,12 @@ EOT
     end.to raise_error(Puppet::Error, %r{Cannot get plugin status})
   end
 
-  it 'should call jmeterplugins to create' do
+  it 'calls jmeterplugins to create' do
     @provider.expects(:jmeterplugins).with('install', 'foo')
     @provider.create
   end
-  it 'should call jmeterplugins to destroy' do
+  it 'calls jmeterplugins to destroy' do
     @provider.expects(:jmeterplugins).with('uninstall', 'foo')
     @provider.destroy
   end
-
 end

--- a/spec/unit/puppet/provider/jmeter_plugin/jmeterplugins.rb
+++ b/spec/unit/puppet/provider/jmeter_plugin/jmeterplugins.rb
@@ -17,10 +17,26 @@ describe provider_class do
 
   it 'should return instances' do
     provider_class.expects(:jmeterplugins).with('status').returns <<-EOT
-[foo=3.0]
+INFO    2017-10-11 20:07:17.864 [org.jmet] (): Command is: status
+WARN    2017-10-11 20:07:17.963 [org.jmet] (): Found JAR conflict: /usr/share/apache-jmeter-2.9/lib/commons-jexl-2.1.1.jar and /usr/share/apache-jmeter-2.9/lib/commons-jexl-1.1.jar
+[foo=3.0, jmeter-ftp=2.9]
 EOT
     instances = provider_class.instances
-    expect(instances.size).to eq(1)
+    expect(instances.size).to eq(2)
+  end
+
+  it 'errors if the expected output is not found' do
+    provider_class.expects(:jmeterplugins).with('status').returns <<-EOT
+ERROR: java.lang.IllegalArgumentException: Command parameter is missing
+*** Problem's technical details go below ***
+Home directory was detected as: /usr/share/apache-jmeter-2.9/lib
+Exception in thread "main" java.lang.IllegalArgumentException: Command parameter is missing
+	at org.jmeterplugins.repository.PluginManagerCMD.processParams(PluginManagerCMD.java:52)
+	at kg.apc.cmdtools.PluginsCMD.processParams(PluginsCMD.java:66)
+EOT
+    expect do
+      provider_class.instances
+    end.to raise_error(Puppet::Error, %r{Cannot get plugin status})
   end
 
   it 'should call jmeterplugins to create' do

--- a/spec/unit/puppet/type/jmeter_plugin_spec.rb
+++ b/spec/unit/puppet/type/jmeter_plugin_spec.rb
@@ -1,20 +1,20 @@
 require 'spec_helper'
 describe Puppet::Type.type(:jmeter_plugin) do
-  before :each do
-    @plugin = Puppet::Type.type(:jmeter_plugin).new(:name => 'foo')
+  before do
+    @plugin = Puppet::Type.type(:jmeter_plugin).new(name: 'foo')
   end
-  it 'should accept a plugin name' do
+  it 'accepts a plugin name' do
     @plugin[:name] = 'plugin-name'
     expect(@plugin[:name]).to eq('plugin-name')
   end
-  it 'should require a name' do
-    expect {
+  it 'requires a name' do
+    expect do
       Puppet::Type.type(:jmeter_plugin).new({})
-    }.to raise_error(Puppet::Error, 'Title or name must be provided')
+    end.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
-  it 'should not allow invalid names to be specified' do
-    expect {
+  it 'does not allow invalid names to be specified' do
+    expect do
       @plugin[:name] = 'this has a space'
-    }.to raise_error(Puppet::Error, /Parameter name failed on Jmeter_plugin/)
+    end.to raise_error(Puppet::Error, %r{Parameter name failed on Jmeter_plugin})
   end
 end

--- a/spec/unit/puppet/type/jmeter_plugin_spec.rb
+++ b/spec/unit/puppet/type/jmeter_plugin_spec.rb
@@ -1,11 +1,12 @@
 require 'spec_helper'
 describe Puppet::Type.type(:jmeter_plugin) do
-  before do
-    @plugin = Puppet::Type.type(:jmeter_plugin).new(name: 'foo')
+  let(:plugin) do
+    Puppet::Type.type(:jmeter_plugin).new(name: 'foo')
   end
+
   it 'accepts a plugin name' do
-    @plugin[:name] = 'plugin-name'
-    expect(@plugin[:name]).to eq('plugin-name')
+    plugin[:name] = 'plugin-name'
+    expect(plugin[:name]).to eq('plugin-name')
   end
   it 'requires a name' do
     expect do
@@ -14,7 +15,7 @@ describe Puppet::Type.type(:jmeter_plugin) do
   end
   it 'does not allow invalid names to be specified' do
     expect do
-      @plugin[:name] = 'this has a space'
+      plugin[:name] = 'this has a space'
     end.to raise_error(Puppet::Error, %r{Parameter name failed on Jmeter_plugin})
   end
 end

--- a/templates/jmeter-init.erb
+++ b/templates/jmeter-init.erb
@@ -15,12 +15,10 @@
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="Apache JMeter Remote Server"
 NAME=jmeter
+JMETER_USER=<%= @jmeter_user %>
 JMETER_PATH=/usr/share/jmeter
-# Change this to your IP
-JMETER_IP=<%= @bind_ip %>
-JMETER_PORT=1099
-DAEMON="$JMETER_PATH/bin/$NAME"
-DAEMON_ARGS="-Djava.rmi.server.hostname=$JMETER_IP -Dserver_port=$JMETER_PORT -s -j $JMETER_PATH/bin/jmeter-server.log"
+DAEMON="$JMETER_PATH/bin/$NAME.sh"
+DAEMON_ARGS="-s -Djava.rmi.server.hostname=<%= @bind_ip %> -Dserver_port=<%= @bind_port %> -j /var/log/jmeter/jmeter-server.log"
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 
@@ -46,9 +44,9 @@ do_start()
         #   0 if daemon has been started
         #   1 if daemon was already running
         #   2 if daemon could not be started
-        start-stop-daemon --start --quiet --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
+        start-stop-daemon --start --chuid $JMETER_USER --quiet --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
                 || return 1
-        start-stop-daemon --start --quiet --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON -- \
+        start-stop-daemon --start --chuid $JMETER_USER --quiet --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON -- \
                 $DAEMON_ARGS \
                 || return 2
         # Add code here, if necessary, that waits for the process to be ready

--- a/templates/jmeter-init.erb
+++ b/templates/jmeter-init.erb
@@ -75,6 +75,8 @@ do_stop()
         # sleep for some time.
         start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec $DAEMON
         [ "$?" = 2 ] && return 2
+        # Also make sure children are killed.
+        pkill -P `cat $PIDFILE`
         # Many daemons don't delete their pidfiles when they exit.
         rm -f $PIDFILE
         return "$RETVAL"

--- a/templates/jmeter-init.redhat.erb
+++ b/templates/jmeter-init.redhat.erb
@@ -16,15 +16,13 @@
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="Apache JMeter Remote Server"
 NAME=jmeter
+JMETER_USER=<%= @jmeter_user %>
 JMETER_PATH=/usr/share/jmeter
-# RMI_HOST_DEF is used inside the $JMETER_PATH/bin/$NAME-server script
-# Change this to your IP
-export RMI_HOST_DEF="-Djava.rmi.server.hostname=<%= @bind_ip %>"
-SERVER_PORT=1099
-SERVER_CMD="$JMETER_PATH/bin/$NAME-server"
+SERVER_ARGS="-s -Djava.rmi.server.hostname=<%= @bind_ip %> -Dserver_port=<%= @bind_port %> -j /var/log/jmeter/jmeter-server.log"
+SERVER_CMD="${JMETER_PATH}/bin/${NAME}.sh"
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
-JAVA_PID=$(pgrep -f "[A]pacheJMeter.jar $RMI_HOST_DEF -Dserver_port=1099")
+JAVA_PID=$(pgrep -f "[A]pacheJMeter.jar ${SERVER_ARGS}")
 
 # Source function library.
 . /etc/rc.d/init.d/functions
@@ -42,7 +40,7 @@ JAVA_PID=$(pgrep -f "[A]pacheJMeter.jar $RMI_HOST_DEF -Dserver_port=1099")
 #
 update_pid()
 {
-    JAVA_PID=$(pgrep -f "[A]pacheJMeter.jar $RMI_HOST_DEF -Dserver_port=1099")
+    JAVA_PID=$(pgrep -f "[A]pacheJMeter.jar ${SERVER_ARGS}")
 }
 
 #
@@ -52,7 +50,7 @@ do_start()
 {
         [ -n "$JAVA_PID" ] && echo "$NAME already started" && exit 0
         echo -n "Starting $NAME: "
-        $JMETER_PATH/bin/$NAME-server 2>&1 &
+        runuser $JMETER_USER $SERVER_CMD -- $SERVER_ARGS 2>&1 &
         RETVAL=$?
         MODE="normal"
         echo "$NAME started in $MODE mode"

--- a/templates/jmeter.service.erb
+++ b/templates/jmeter.service.erb
@@ -1,0 +1,10 @@
+[Unit]
+Description=Jmeter Server Service
+
+[Service]
+User=<%= @jmeter_user %>
+ExecStart=/usr/share/jmeter/bin/jmeter.sh -s -Djava.rmi.server.hostname=<%= @bind_ip %> -Dserver_port=<%= @bind_port %> -j /var/log/jmeter/jmeter-server.log
+Type=simple
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This is a major PR with some potentially breaking changes. This is based off of #12 and #13, so will need a rebase against master if / when those are merged.

c08e350 is the commit that has the changes for this changeset.

Updates in this PR:
- Configure a user / group 'jmeter' (username is configurable), and run jmeter as this user. I have tested, but haven't tested upgrading in place -- I think it should work, however.
- Configure `/var/log/jmeter/` so that logs can be written here.
- Bump default version on systems with Java 8 to jmeter 3.3
- Set default version to 2.9 on systems with Java 7 (was documented before but broken with default settings)
- Bump plugin manager version, and improve error handling.
- Add nodeset for CentOS 6
- Switch to systemd on systems that support it
- Update acceptance tests
- Some fixes for style based on rubocop's feedback (including some auto-fixes). These changes are all in two separate commits for easier review.

Could also switch to parallel rspec tests at some point. Let me know if there's missing test coverage that should be improved.