### PR TITLE
Add WorkingDirectory to systemd template

### DIFF
--- a/templates/jmeter.service.erb
+++ b/templates/jmeter.service.erb
@@ -3,6 +3,7 @@ Description=Jmeter Server Service
 
 [Service]
 User=<%= @jmeter_user %>
+WorkingDirectory=/usr/share/jmeter/bin
 ExecStart=/usr/share/jmeter/bin/jmeter.sh -s -Djava.rmi.server.hostname=<%= @bind_ip %> -Dserver_port=<%= @bind_port %> -j /var/log/jmeter/jmeter-server.log
 Type=simple
 


### PR DESCRIPTION
When using jmeter 4.0 with SSL - a file named rmi_keystore.jks gets generated and placed into the jmeter/bin folder. If the working directory is not the bin directory - jmeter fails to see this file and fails to start.